### PR TITLE
Starting a docs index landing page.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -4,9 +4,24 @@ require ''
 views = [:index, :videos]  # Allowed views
 docs = Dir['docs/**/*.md'] # All markdown files in docs/
 
+# Chop off any trailing slashes. This will make the two routes,
+# '/foo/bar' and '/foo/bar/' equivalent in the eyes of both the
+# user and our application.
+#
+# This means it is __CRITITCAL__ that no routes be specified with
+# trailing slashes, as they will never ever ever be hit.
+before { request.path_info.sub! %r{/$}, '' }
+
 get '/' do
   @content = "Welcome to the Home Page"
   erb :index
+end
+
+# Index page for the docs. Users can start to navigate the docs
+# from here. Furthermore, this will be a fantastic place to link
+# directly to, so consider it almost a landing page.
+get '/docs' do
+  erb :docs, :locals => { :docs => docs }
 end
 
 # Find in Docs

--- a/views/docs.erb
+++ b/views/docs.erb
@@ -1,0 +1,5 @@
+<h1>Docs Index</h1>
+
+<% docs.each do |doc| %>
+<li><a href="<%= doc.chomp('.md') %>"><%= doc.chomp('.md') %></a></li>
+<% end %>


### PR DESCRIPTION
Keep this PR open until we are satisfied with the content on it. We don't need to start worrying about the design or anything, just as is it's not even remotly done. For example the links all have 'docs/' in front of them.

At some point the Markdown files in docs/ should really have a class made for them to help deal with them. But we can talk more about that later.

This commit also fixes problems with trailing slashes in routes. Your welcome in advance.
